### PR TITLE
Add Support to Apache Spark

### DIFF
--- a/octopus/src/main/scala/octopus/AppError.scala
+++ b/octopus/src/main/scala/octopus/AppError.scala
@@ -2,14 +2,14 @@ package octopus
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait AppError[M[_]] {
+trait AppError[M[_]] extends Serializable{
   def pure[A](a: A): M[A]
   def map2[A, B, C](first: M[A], second: M[B])(combine: (A, B) => C): M[C]
   def recover[A, B <: A](app: M[A], f: Throwable => B): M[A]
   def map[A, B](fa: M[A])(f: A => B): M[B]
 }
 
-object AppError {
+object AppError extends Serializable {
   def apply[M[_]](implicit a: AppError[M]): AppError[M] = a
 
   implicit def futureAppError(implicit ec: ExecutionContext): AppError[Future] = new AppError[Future] {

--- a/octopus/src/main/scala/octopus/AsyncValidationRules.scala
+++ b/octopus/src/main/scala/octopus/AsyncValidationRules.scala
@@ -7,7 +7,7 @@ import scala.language.higherKinds
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
-object AsyncValidationRules {
+object AsyncValidationRules extends Serializable {
 
   def rule[M[_]: AppError, T](asyncPred: T => M[Boolean], whenInvalid: String): AsyncValidatorM[M, T] =
     instance { (obj: T) =>

--- a/octopus/src/main/scala/octopus/AsyncValidator.scala
+++ b/octopus/src/main/scala/octopus/AsyncValidator.scala
@@ -3,7 +3,7 @@ package octopus
 import scala.concurrent.Future
 import scala.language.higherKinds
 
-private[octopus] object AsyncValidator {
+private[octopus] object AsyncValidator extends Serializable {
   def apply[T](implicit appError: AppError[Future]): octopus.dsl.AsyncValidator[T] =
     AsyncValidatorM.lift[Future, T](Validator.apply[T])
 }
@@ -12,7 +12,7 @@ trait AsyncValidatorM[M[_], T] {
   def validate(obj: T)(implicit appError: AppError[M]): M[List[ValidationError]]
 }
 
-object AsyncValidatorM {
+object AsyncValidatorM extends Serializable {
 
   def instance[M[_], T](f: T => M[List[ValidationError]]): AsyncValidatorM[M, T] = {
     new AsyncValidatorM[M, T] {

--- a/octopus/src/main/scala/octopus/DerivedAsyncValidator.scala
+++ b/octopus/src/main/scala/octopus/DerivedAsyncValidator.scala
@@ -42,7 +42,7 @@ object DerivedAsyncValidator extends LowPriorityAsyncValidatorDerivation {
     }
 }
 
-trait LowPriorityAsyncValidatorDerivation {
+trait LowPriorityAsyncValidatorDerivation extends Serializable{
 
   implicit def fromSyncValidator[M[_]: AppError, T](implicit v: Validator[T]): DerivedAsyncValidator[M, T] =
     DerivedAsyncValidator(AsyncValidatorM.lift(v))

--- a/octopus/src/main/scala/octopus/DerivedValidator.scala
+++ b/octopus/src/main/scala/octopus/DerivedValidator.scala
@@ -42,7 +42,7 @@ object DerivedValidator extends LowPriorityValidatorDerivation {
   }
 }
 
-trait LowPriorityValidatorDerivation {
+trait LowPriorityValidatorDerivation extends Serializable{
 
   implicit val hnilValidator: DerivedValidator[HNil] = DerivedValidator(Validator[HNil])
 

--- a/octopus/src/main/scala/octopus/DslMacros.scala
+++ b/octopus/src/main/scala/octopus/DslMacros.scala
@@ -2,7 +2,7 @@ package octopus
 
 import scala.language.higherKinds
 
-private[octopus] object DslMacros {
+private[octopus] object DslMacros extends Serializable {
 
   def ruleFieldSelector[T: c.WeakTypeTag, F: c.WeakTypeTag](c: scala.reflect.macros.blackbox.Context)
                                                            (selector: c.Expr[T => F],

--- a/octopus/src/main/scala/octopus/FieldPath.scala
+++ b/octopus/src/main/scala/octopus/FieldPath.scala
@@ -1,6 +1,6 @@
 package octopus
 
-sealed trait PathElement extends Any {
+sealed trait PathElement extends Any with Serializable{
   def asString: String
 }
 
@@ -17,7 +17,7 @@ case class MapKey(key: String) extends AnyVal with PathElement {
 }
 
 
-case class FieldPath(parts: List[PathElement]) extends AnyVal {
+case class FieldPath(parts: List[PathElement]) extends AnyVal with Serializable {
 
   def ::(element: PathElement): FieldPath =
     copy(element :: parts)
@@ -36,7 +36,7 @@ case class FieldPath(parts: List[PathElement]) extends AnyVal {
   }
 }
 
-object FieldPath {
+object FieldPath extends Serializable {
 
   val empty = FieldPath(Nil)
 }

--- a/octopus/src/main/scala/octopus/ValidationError.scala
+++ b/octopus/src/main/scala/octopus/ValidationError.scala
@@ -1,6 +1,6 @@
 package octopus
 
-case class ValidationError(message: String, path: FieldPath = FieldPath.empty) {
+case class ValidationError(message: String, path: FieldPath = FieldPath.empty) extends Serializable {
 
   def ::(pathElement: PathElement): ValidationError =
     copy(path = pathElement :: path)

--- a/octopus/src/main/scala/octopus/ValidationResult.scala
+++ b/octopus/src/main/scala/octopus/ValidationResult.scala
@@ -6,7 +6,7 @@ import shapeless.tag.@@
 import scala.language.higherKinds
 
 
-sealed class ValidationResult[T](private[octopus] val value: T, val errors: List[ValidationError]) {
+sealed class ValidationResult[T](private[octopus] val value: T, val errors: List[ValidationError]) extends Serializable {
 
   /**
     * Eager validation composition

--- a/octopus/src/main/scala/octopus/ValidationRules.scala
+++ b/octopus/src/main/scala/octopus/ValidationRules.scala
@@ -6,7 +6,7 @@ import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
-object ValidationRules {
+object ValidationRules extends Serializable {
 
   def rule[T](pred: T => Boolean, whenInvalid: String): Validator[T] =
     (obj: T) => if (pred(obj)) Nil else List(ValidationError(whenInvalid))

--- a/octopus/src/main/scala/octopus/Validator.scala
+++ b/octopus/src/main/scala/octopus/Validator.scala
@@ -1,11 +1,11 @@
 package octopus
 
-trait Validator[T] {
+trait Validator[T] extends Serializable{
 
   def validate(obj: T): List[ValidationError]
 }
 
-object Validator {
+object Validator extends Serializable {
 
   def instance[T](f: T => List[ValidationError]): Validator[T] =
     new Validator[T] {

--- a/octopus/src/main/scala/octopus/dsl.scala
+++ b/octopus/src/main/scala/octopus/dsl.scala
@@ -19,7 +19,7 @@ object dsl {
   type AsyncValidator[T] = octopus.AsyncValidatorM[Future, T]
   val AsyncValidator = octopus.AsyncValidator
 
-  implicit class ValidatorOps[T](val v: Validator[T]) extends AnyVal {
+  implicit class ValidatorOps[T](val v: Validator[T]) extends AnyVal with Serializable {
 
     def compose(v2: Validator[T]): Validator[T] =
       (obj: T) => v.validate(obj) ++ v2.validate(obj)
@@ -69,7 +69,7 @@ object dsl {
       new AsyncValidatorAsyncOps[M, T](AsyncValidatorM.lift[M, T](v))
   }
 
-  class AsyncValidatorAsyncOps[M[_], T](val v: AsyncValidatorM[M, T]) extends AnyVal {
+  class AsyncValidatorAsyncOps[M[_], T](val v: AsyncValidatorM[M, T]) extends AnyVal with Serializable {
 
     def compose(v2: AsyncValidatorM[M, T])(implicit appError: AppError[M]): AsyncValidatorM[M, T] =
       AsyncValidatorM.instance[M, T] { (obj: T) =>
@@ -124,7 +124,7 @@ object dsl {
 
   }
 
-  implicit class AsyncValidatorSyncOps[M[_], T](val v: AsyncValidatorM[M, T]) extends AnyVal {
+  implicit class AsyncValidatorSyncOps[M[_], T](val v: AsyncValidatorM[M, T]) extends AnyVal with Serializable {
 
     def async: AsyncValidatorAsyncOps[M, T] =
       new AsyncValidatorAsyncOps[M, T](v)

--- a/octopus/src/main/scala/octopus/syntax.scala
+++ b/octopus/src/main/scala/octopus/syntax.scala
@@ -5,7 +5,7 @@ import scala.language.higherKinds
 
 object syntax {
 
-  implicit class ValidationOps[T](val obj: T) extends AnyVal {
+  implicit class ValidationOps[T](val obj: T) extends AnyVal with Serializable {
 
     def validate(implicit v: Validator[T]): ValidationResult[T] =
       new ValidationResult(obj, v.validate(obj))
@@ -14,7 +14,7 @@ object syntax {
       validate.isValid
   }
 
-  implicit class AsyncValidationOps[T](val obj: T) extends AnyVal {
+  implicit class AsyncValidationOps[T](val obj: T) extends AnyVal with Serializable {
 
     def validateAsync(implicit av: AsyncValidatorM[Future, T], appError: AppError[Future]): Future[ValidationResult[T]] =
       appError.map(av.validate(obj)) { errors =>

--- a/octopusCats/src/main/scala/octopus/cats/package.scala
+++ b/octopusCats/src/main/scala/octopus/cats/package.scala
@@ -4,7 +4,7 @@ import _root_.cats.data.{NonEmptyList, Validated, ValidatedNel}
 
 package object cats {
 
-  implicit class OctopusCatsOps[T](val vr: ValidationResult[T]) extends AnyVal {
+  implicit class OctopusCatsOps[T](val vr: ValidationResult[T]) extends AnyVal with Serializable {
 
     def toValidatedNel: ValidatedNel[ValidationError, T] = vr.errors match {
       case Nil =>

--- a/octopusScalaz/src/main/scala/octopus/scalaz/package.scala
+++ b/octopusScalaz/src/main/scala/octopus/scalaz/package.scala
@@ -4,7 +4,7 @@ import _root_.scalaz.{NonEmptyList, Validation, ValidationNel}
 
 package object scalaz {
 
-  implicit class OctopusScalazOps[T](val vr: ValidationResult[T]) extends AnyVal {
+  implicit class OctopusScalazOps[T](val vr: ValidationResult[T]) extends AnyVal with Serializable {
 
     def toValidationNel: ValidationNel[ValidationError, T] = vr.errors match {
       case Nil =>


### PR DESCRIPTION
This is a small change, but it will enable this library to be used inside Apache Spark applications. As the code can be send to a different worker, it needs to be Serializable. 