### PR TITLE
Add long validator

### DIFF
--- a/octopus/src/main/scala/octopus/DerivedValidator.scala
+++ b/octopus/src/main/scala/octopus/DerivedValidator.scala
@@ -11,6 +11,7 @@ object DerivedValidator extends LowPriorityValidatorDerivation {
 
   implicit val stringValidator: DerivedValidator[String] = DerivedValidator(Validator[String])
   implicit val intValidator: DerivedValidator[Int] = DerivedValidator(Validator[Int])
+  implicit val longValidator: DerivedValidator[Long] = DerivedValidator(Validator[Long])
   implicit val boolValidator: DerivedValidator[Boolean] = DerivedValidator(Validator[Boolean])
   implicit val doubleValidator: DerivedValidator[Double] = DerivedValidator(Validator[Double])
   implicit val floatValidator: DerivedValidator[Float] = DerivedValidator(Validator[Float])


### PR DESCRIPTION
When you have a case class with a long value then try to use Validator.derived you get an indecipherable error "could not find implicit value for parameter dv: octopus.DerivedValidator". I assume missing this validator is why. 