### PR TITLE
#52: scalafmt formatter and ignore metals/vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,14 @@ project/project
 project/target
 target
 .idea
+logs
 
+# Metals & VSCode #
+/.classpath
+/.project
+/.settings
+/.metals
+/.g8
+/.bloop
+/RUNNING_PID
+settings.json

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,21 @@
+version = 2.7.5
+
+preset = defaultWithAlign
+
+align.tokens = [off]
+align.openParenDefnSite = true
+align.openParenCallSite = true
+danglingParentheses = true
+indentOperator.preset = spray
+maxColumn = 120
+rewrite.rules = [RedundantBraces, RedundantParens, SortImports]
+rewrite.redundantBraces.stringInterpolation = true
+rewrite.redundantBraces.generalExpressions = true
+rewrite.redundantBraces.ifElseExpressions = true
+rewrite.redundantBraces.methodBodies = true
+rewrite.redundantBraces.stringInterpolation = true
+rewrite.redundantBraces.parensForOneLineApply = true
+newlines.afterCurlyLambdaParams = squash
+unindentTopLevelOperators  = true
+continuationIndent.defnSite = 2
+docstrings = ScalaDoc


### PR DESCRIPTION
Here's a `.scalafmt.conf` that I normally use, but happy to adopt whatever the project would prefer. To get IntelliJ to use it, you can set it up as follows: (it'll pick it up in the root)

![image](https://user-images.githubusercontent.com/138898/97804774-34272580-1c0f-11eb-81e8-a469d90d8253.png)

I also included a few adjustments to the ignore file for those (me) that are using Metals/VSCode.